### PR TITLE
feat: improves Boost integration using custom CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,10 @@ if(${FORCE_COLORED_OUTPUT})
 endif()
 
 # Find required packages
-find_package(Boost REQUIRED CONFIG COMPONENTS system url)
+set(BOOST_COMPILED_COMPONENTS url)
+set(BOOST_HEADER_ONLY_COMPONENTS asio beast outcome signals2 system)
+include(cmake/lib_boost.cmake)
+
 find_package(OpenSSL REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
@@ -35,8 +38,8 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Link libraries
-target_link_libraries(centrifugo-cpp Boost::system Boost::url OpenSSL::SSL
-                      OpenSSL::Crypto nlohmann_json::nlohmann_json)
+target_link_libraries(centrifugo-cpp ${BOOST_LIBS} OpenSSL::SSL OpenSSL::Crypto
+                      nlohmann_json::nlohmann_json)
 
 # Compiler options
 target_compile_options(centrifugo-cpp PRIVATE -Wall -Wextra)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.17)
 project(centrifugo-cpp VERSION 0.2.0)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -21,9 +21,8 @@ endif()
 set(BOOST_COMPILED_COMPONENTS url)
 set(BOOST_HEADER_ONLY_COMPONENTS asio beast outcome signals2 system)
 include(cmake/lib_boost.cmake)
-
+include(cmake/lib_nlohmann_json.cmake)
 find_package(OpenSSL REQUIRED)
-find_package(nlohmann_json REQUIRED)
 
 # Create the library target
 file(GLOB_RECURSE SOURCES "src/*.cpp" "include/*.h")
@@ -38,8 +37,8 @@ target_include_directories(
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Link libraries
-target_link_libraries(centrifugo-cpp ${BOOST_LIBS} OpenSSL::SSL OpenSSL::Crypto
-                      nlohmann_json::nlohmann_json)
+target_link_libraries(centrifugo-cpp PUBLIC ${BOOST_LIBS} nlohmann_json::nlohmann_json
+                      OpenSSL::SSL OpenSSL::Crypto)
 
 # Compiler options
 target_compile_options(centrifugo-cpp PRIVATE -Wall -Wextra)
@@ -56,6 +55,10 @@ if(BUILD_EXAMPLES)
 endif()
 
 # ==== INSTALLATION ====
+
+include(GNUInstallDirs)
+
+install_nlohmann_json()
 
 install(
   TARGETS centrifugo-cpp

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/lib_boost.cmake
+++ b/cmake/lib_boost.cmake
@@ -1,0 +1,65 @@
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+#
+# MIT License
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# Define BOOST_COMPILED_COMPONENTS and BOOST_HEADER_ONLY_COMPONENTS lists
+# then include this module and in for the target add ${BOOST_LIBS}:
+# target_link_libraries(${PROJECT_NAME} PRIVATE ${BOOST_LIBS})
+
+# Author: Dilshod Mukhtarov, 2025
+
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
+
+set(TRY_BOOST_VERSION 1.89.0) # Set the desired Boost version here for fetching by CPM
+
+# Don't use find_package if boost was added by CPM, otherwise can't find include files
+if(NOT BOOST_ADDED_BY_CPM)
+    find_package(Boost COMPONENTS ${BOOST_COMPILED_COMPONENTS} QUIET)
+endif()
+
+if(Boost_FOUND)
+    set(BOOST_ADDED_BY_CPM OFF)
+    message(STATUS "Using system Boost version ${Boost_VERSION}")
+    set(BOOST_LIBS ${Boost_LIBRARIES})
+else()
+    set(BOOST_ADDED_BY_CPM ON)
+    message(STATUS "System Boost not found, fetching Boost ${TRY_BOOST_VERSION} using CPM.")
+
+    set(Boost_USE_STATIC_LIBS ON) # only find static libs
+    set(Boost_USE_DEBUG_LIBS OFF) # ignore debug libs and
+    set(Boost_USE_RELEASE_LIBS ON) # only find release libs
+    set(Boost_USE_MULTITHREADED ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+
+    # url for 1.85.0 + only
+    set(BOOST_URL
+        "https://github.com/boostorg/boost/releases/download/boost-${TRY_BOOST_VERSION}/boost-${TRY_BOOST_VERSION}-cmake.tar.xz"
+    )
+
+    CPMAddPackage(
+        NAME Boost
+        URL ${BOOST_URL}
+        EXCLUDE_FROM_ALL YES
+        SYSTEM YES
+        OPTIONS "BOOST_ENABLE_CMAKE ON" "BOOST_SKIP_INSTALL_RULES OFF"
+    )
+
+    set(BOOST_LIBS "") # Initialize an empty list to collect libraries
+
+    # Collect header-only Boost libraries
+    foreach(a_lib ${BOOST_HEADER_ONLY_COMPONENTS})
+        list(APPEND BOOST_LIBS boost_${a_lib})
+    endforeach()
+
+    # Collect compiled Boost libraries
+    foreach(a_lib ${BOOST_COMPILED_COMPONENTS})
+        list(APPEND BOOST_LIBS Boost::${a_lib})
+    endforeach()
+endif()

--- a/cmake/lib_nlohmann_json.cmake
+++ b/cmake/lib_nlohmann_json.cmake
@@ -1,0 +1,88 @@
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+#
+# MIT License
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# IMPORTNANT: Add this if you want to install nlohmann_json for downstream users:
+# install_nlohmann_json()
+
+# Author: Dilshod Mukhtarov, 2025
+
+include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
+
+set(TRY_NLOHMANN_JSON_VERSION 3.12.0) # Set the desired version here for fetching by CPM
+
+# Don't use find_package if package was added by CPM, otherwise can't find include files
+if(NOT NLOHMANN_JSON_ADDED_BY_CPM)
+    find_package(nlohmann_json QUIET)
+endif()
+
+if(nlohmann_json_FOUND)
+    set(NLOHMANN_JSON_ADDED_BY_CPM OFF)
+    message(STATUS "Using system nlohmann_json version ${nlohmann_json_VERSION}")
+else()
+    set(NLOHMANN_JSON_ADDED_BY_CPM ON)
+    message(STATUS "System nlohmann-json not found, fetching version ${TRY_NLOHMANN_JSON_VERSION} using CPM.")
+
+    # CPMAddPackage(NAME nlohmann_json URL https://github.com/nlohmann/json/releases/download/v${TRY_NLOHMANN_JSON_VERSION}/json.tar.xz)
+    # Fetch with CPM but don't add to build
+     CPMAddPackage(
+         NAME nlohmann_json
+         URL https://github.com/nlohmann/json/releases/download/v${TRY_NLOHMANN_JSON_VERSION}/json.tar.xz
+         DOWNLOAD_ONLY YES  # Only download, don't add to build
+     )
+
+     # Create an IMPORTED target manually (like find_package would do)
+     if(NOT TARGET nlohmann_json::nlohmann_json)
+         add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED GLOBAL)
+
+         # Set the include directory - make sure the path is correct
+         if(EXISTS "${nlohmann_json_SOURCE_DIR}/include/nlohmann/json.hpp")
+             set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+                 INTERFACE_INCLUDE_DIRECTORIES "${nlohmann_json_SOURCE_DIR}/include"
+             )
+             message(STATUS "Created IMPORTED target nlohmann_json::nlohmann_json with include dir: ${nlohmann_json_SOURCE_DIR}/include")
+         else()
+             message(FATAL_ERROR "nlohmann_json header not found at expected location: ${nlohmann_json_SOURCE_DIR}/include/nlohmann/json.hpp")
+         endif()
+     endif()
+endif()
+
+# Function to install nlohmann_json when fetched via CPM
+function(install_nlohmann_json)
+    if(NLOHMANN_JSON_ADDED_BY_CPM)
+        # Install the headers
+        install(
+            DIRECTORY "${nlohmann_json_SOURCE_DIR}/include/"
+            DESTINATION include
+            FILES_MATCHING PATTERN "*.hpp"
+        )
+
+        # Generate a proper config file for downstream consumers
+        set(NLOHMANN_JSON_CONFIG_CONTENT "
+# Auto-generated config file for nlohmann_json (installed via CPM)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
+    set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES \"\${CMAKE_CURRENT_LIST_DIR}/../../../include\"
+    )
+endif()
+
+set(nlohmann_json_FOUND TRUE)
+set(nlohmann_json_VERSION \"${TRY_NLOHMANN_JSON_VERSION}\")
+")
+
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_json-config.cmake"
+            "${NLOHMANN_JSON_CONFIG_CONTENT}"
+        )
+
+        install(
+            FILES "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_json-config.cmake"
+            DESTINATION lib/cmake/nlohmann_json
+        )
+
+        message(STATUS "nlohmann_json headers and config will be installed")
+    endif()
+endfunction()


### PR DESCRIPTION
Migrates from direct `find_package(Boost)` to boost.cmake for better control over static/dynamic libs.
Fixes build issues with Boost 1.89.0 where system component became header-only.
Adds CPM for optional Boost download if not found in system.
