### PR TITLE
Refresh token before expiry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.17)
-project(centrifugo-cpp VERSION 0.4.0)
+project(centrifugo-cpp VERSION 0.5.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/centrifugo/common.h
+++ b/include/centrifugo/common.h
@@ -25,6 +25,7 @@ struct ClientConfig {
     std::string version;
 
     std::chrono::seconds maxPingDelay {10};
+    std::chrono::seconds refreshTokenBeforeExpiry {180}; // Refresh token when 3 minutes remain
     std::chrono::milliseconds minReconnectDelay {200};
     std::chrono::milliseconds maxReconnectDelay {20000};
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -444,7 +444,12 @@ auto Transport::startPingTimer() -> void
 
 auto Transport::startTokenRefreshTimer(std::uint32_t ttlSeconds) -> void
 {
-    tokenRefreshTimer_.expires_after(chrono::seconds {ttlSeconds});
+    auto expiryTime = std::chrono::seconds {ttlSeconds};
+    if (expiryTime > config_.refreshTokenBeforeExpiry) {
+        expiryTime -= config_.refreshTokenBeforeExpiry;
+    }
+
+    tokenRefreshTimer_.expires_after(expiryTime);
     tokenRefreshTimer_.async_wait([this](boost::system::error_code ec) {
         if (ec) {
             if (ec == net::error::operation_aborted) {


### PR DESCRIPTION
Introduces configurable refresh token timing to initiate refresh. Default value is 3 minutes before token expiration.
