### PR TITLE
Session Resilience [2/5]: Stream recovery support for subscriptions

### DIFF
--- a/src/subscription_impl.cpp
+++ b/src/subscription_impl.cpp
@@ -24,10 +24,15 @@ SubscriptionImpl::SubscriptionImpl(SubscriptionImpl &&other) noexcept
     , transport_ {other.transport_}
     , subscription_ {this}
     , state_ {other.state_}
+    , waitingReplies_ {std::move(other.waitingReplies_)}
+    , epoch_ {std::move(other.epoch_)}
+    , offset_ {other.offset_}
+    , recoverable_ {other.recoverable_}
     , subscribingSignal_ {std::move(other.subscribingSignal_)}
     , subscribedSignal_ {std::move(other.subscribedSignal_)}
     , unsubscribedSignal_ {std::move(other.unsubscribedSignal_)}
     , publicationSignal_ {std::move(other.publicationSignal_)}
+    , errorSignal_ {std::move(other.errorSignal_)}
 {
     other.deinit();
     init();

--- a/src/subscription_impl.cpp
+++ b/src/subscription_impl.cpp
@@ -69,6 +69,11 @@ auto SubscriptionImpl::unsubscribe() -> void
         return;
     }
 
+    // Clear recovery state so a subsequent subscribe() starts fresh
+    recoverable_ = false;
+    epoch_.clear();
+    offset_ = 0;
+
     if (transport_.state() == ConnectionState::Connected) {
         sendCmd(makeCommand(UnsubscribeRequest {channel_}));
     } else {

--- a/src/subscription_impl.cpp
+++ b/src/subscription_impl.cpp
@@ -176,12 +176,8 @@ auto SubscriptionImpl::handleReply(Reply const &reply) -> bool
                 } else if constexpr (std::is_same_v<ResultType, SubscribeResult>) {
                     // Store stream position for recovery on reconnect
                     recoverable_ = result.recoverable;
-                    if (!result.epoch.empty()) {
-                        epoch_ = result.epoch;
-                    }
-                    if (result.offset > 0) {
-                        offset_ = result.offset;
-                    }
+                    epoch_ = result.epoch;
+                    offset_ = result.offset;
 
                     setState(SubscriptionState::SUBSCRIBED);
                     for (auto const &publication : result.publications) {

--- a/src/subscription_impl.cpp
+++ b/src/subscription_impl.cpp
@@ -187,7 +187,12 @@ auto SubscriptionImpl::handleReply(Reply const &reply) -> bool
                     // Store stream position for recovery on reconnect
                     recoverable_ = result.recoverable;
                     epoch_ = result.epoch;
-                    offset_ = result.offset;
+                    // When there are recovered publications, let handlePublish()
+                    // advance offset_ from each one. Otherwise use result.offset
+                    // as the baseline stream position.
+                    if (result.publications.empty()) {
+                        offset_ = result.offset;
+                    }
 
                     setState(SubscriptionState::SUBSCRIBED);
                     for (auto const &publication : result.publications) {

--- a/src/subscription_impl.h
+++ b/src/subscription_impl.h
@@ -60,6 +60,11 @@ private:
     SubscriptionState state_ = SubscriptionState::UNSUBSCRIBED;
     std::unordered_set<std::uint32_t> waitingReplies_;
 
+    // Stream recovery state
+    std::string epoch_;
+    std::uint64_t offset_ {0};
+    bool recoverable_ {false};
+
     SubscribingSignal subscribingSignal_;
     SubscribedSignal subscribedSignal_;
     UnsubscribedSignal unsubscribedSignal_;


### PR DESCRIPTION
## Summary

- Stores `epoch`, `offset`, and `recoverable` from `SubscribeResult` when a subscription succeeds
- Tracks `offset` from each incoming `Publication` to maintain the latest stream position
- On reconnect, sends `recover=true` with the stored `epoch`/`offset` in `SubscribeRequest` so the server replays missed messages
- Recovered publications from the server are delivered normally via `handlePublish()`

**How it works with the server:**
1. Server has `force_recovery: true` → includes recovery metadata in subscribe responses
2. Client stores `epoch`/`offset` from the response
3. Client tracks `offset` from each incoming publication
4. On disconnect → reconnect, client sends `recover=true` + stored position
5. Server replays any messages published between the stored offset and now

**Changes:** `subscription_impl.h` (3 new member variables), `subscription_impl.cpp` (recovery logic in 3 methods)

**For Dilshod to review:** This is a draft for review. The protocol layer (`SubscribeRequest`, `SubscribeResult`, `Publication`) already had all the recovery fields — this PR just wires them up in the subscription lifecycle.
